### PR TITLE
Fixed: Blip does not go away

### DIFF
--- a/StopRightThere/StopRightThere.cs
+++ b/StopRightThere/StopRightThere.cs
@@ -45,7 +45,15 @@ namespace StopRightThere
                                     Functions.StartPulloverOnParkedVehicle(targetVehicle, true, false);
                                     Game.DisplayNotification(targetVehicle.Model.ToString() + "with plate" + targetVehicle.LicensePlate + "pulled over.");
                                     targetVehicle.AttachBlip();
-                                    GameFiber.Sleep(1000);
+                                    while (Functions.IsPlayerPerformingPullover())
+                                    {
+                                        GameFiber.Yield();
+                                    }
+                                    targetVehicle.GetAttachedBlip().Delete(); // when pullover ends, kill the blip
+                                    /* alternative:
+                                    GameFiber.SleepWhile(Functions.IsPlayerPerformingPullover());
+                                    targetVehicle.GetAttachedBlip().Delete(); // when pullover ends, kill the blip
+                                    */
                                 }
                             }
                             catch (Exception e)

--- a/StopRightThere/StopRightThere.cs
+++ b/StopRightThere/StopRightThere.cs
@@ -43,17 +43,7 @@ namespace StopRightThere
                                 {
                                     Game.LogTrivial("SRT: Attempting to start traffic stop");
                                     Functions.StartPulloverOnParkedVehicle(targetVehicle, true, false);
-                                    Game.DisplayNotification(targetVehicle.Model.ToString() + "with plate" + targetVehicle.LicensePlate + "pulled over.");
-                                    targetVehicle.AttachBlip();
-                                    while (Functions.IsPlayerPerformingPullover())
-                                    {
-                                        GameFiber.Yield();
-                                    }
-                                    targetVehicle.GetAttachedBlip().Delete(); // when pullover ends, kill the blip
-                                    /* alternative:
-                                    GameFiber.SleepWhile(Functions.IsPlayerPerformingPullover());
-                                    targetVehicle.GetAttachedBlip().Delete(); // when pullover ends, kill the blip
-                                    */
+                                    Game.DisplayNotification(targetVehicle.Model.Name + " with plate " + targetVehicle.LicensePlate + " pulled over.");
                                 }
                             }
                             catch (Exception e)

--- a/StopRightThere/StopRightThere.csproj
+++ b/StopRightThere/StopRightThere.csproj
@@ -58,6 +58,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
- Working Blips that will dissapear if trafficstop get canceled. if you create mulitple trafficstops at once
- removed vulnerability: multiple pullovers where possible. (resulting in more blips)